### PR TITLE
Cp-598/feat/target 1.16.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This repo is a demo case for the devnetify process.
 1. Download the latest [mainnet state snapshot](https://polkachu.com/tendermint_snapshots/injective) from Polkachu
     - `data` -> `injective-1/data`
     - `wasm` -> `injective-1/wasm`
-2. Run `./injective-1/cli/devnetify-v1.15.0.sh`, wait for it to finish.
-3. Run `./injective-1/cli/injectived-v1.15.0.sh` in separate tab.
-4. Run `./injective-1/cli/apply-upgrade-v1.16.0.sh` (voting time is `10s` as per `custom_overrides.yaml`)
+2. Run `./injective-1/cli/devnetify-v1.16.2.sh`, wait for it to finish.
+3. Run `./injective-1/cli/injectived-v1.16.2.sh` in separate tab.
+4. Run `./injective-1/cli/apply-upgrade-v1.16.3.sh` (voting time is `10s` as per `custom_overrides.yaml`)
 5. Verify it's done and wait until block is reached, stop the node.
-6. Ensure that a local `injectived` binary has `v1.16.0` upgrade handler.
+6. Ensure that a local `injectived` binary has `v1.16.3` upgrade handler.
 7. Run local `injectived` with `./injective-1/cli/injectived-local.sh` and validate the upgrade.
 
 ### Useful endpoints

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-## Testnet/Mainnet Devnetify Testbed
+# Testnet/Mainnet Devnetify Testbed
 
 Allows to take `v1.15.0` state snapshot, devnetify to run it locally with a single validator, and upgrade it with new binary and `v1.16.0` upgrade handler. This allows to test upgrade handler locally for both testnet and mainnet live state.
 
 This repo is a demo case for the devnetify process.
 
-### Steps to re-build the testnet from scratch
+## Steps to re-build the testnet from scratch
 
 1. Download the latest [testnet state snapshot](https://polkachu.com/testnets/injective/snapshots) from Polkachu
     - `data` -> `injective-888/data`
@@ -16,7 +16,7 @@ This repo is a demo case for the devnetify process.
 6. Ensure that a local `injectived` binary has `v1.16.0-beta.2` upgrade handler.
 7. Run local `injectived` with `./injective-888/cli/injectived-local.sh` and validate the upgrade.
 
-### Steps to re-build the mainnet from scratch
+## Steps to re-build the mainnet from scratch
 
 1. Download the latest [mainnet state snapshot](https://polkachu.com/tendermint_snapshots/injective) from Polkachu
     - `data` -> `injective-1/data`
@@ -28,23 +28,25 @@ This repo is a demo case for the devnetify process.
 6. Ensure that a local `injectived` binary has `v1.16.0` upgrade handler.
 7. Run local `injectived` with `./injective-1/cli/injectived-local.sh` and validate the upgrade.
 
-
 ### Useful endpoints
 
 Use this to debug any step of devnetify process.
 
 Last proposal
-```
+
+```http
 http://localhost:10337/cosmos/gov/v1beta1/proposals?pagination.limit=1&pagination.reverse=true
 ```
 
 Voting params
-```
+
+```http
 http://localhost:10337/cosmos/gov/v1/params/voting
 ```
 
 Validators set
-```
+
+```http
 http://localhost:10337/cosmos/staking/v1beta1/validators
 ```
 
@@ -53,6 +55,7 @@ http://localhost:10337/cosmos/staking/v1beta1/validators
 There is a handy Makefile to automate the process.
 
 Default environment values:
+
 ```bash
 CHAIN_ID=888 # set the chain id
 VERSION_FROM=v1.15.0 # set the version from
@@ -60,6 +63,7 @@ VERSION_TO=v1.16.0 # set the version to
 ```
 
 Targets:
+
 ```bash
 make devnetify # devnetify the state
 make apply-upgrade # apply upgrade
@@ -72,4 +76,3 @@ make unpack # unpack the snapshot from the tar.lz4 file
 ```
 
 There is also a `unpack` target to unpack the snapshot from any `*.tar.lz4` file. Just download the snapshot from Polkachu to the target chain dir and run `make unpack`. Use `CHAIN_ID` to set the valid chain dir prefix, e.g. `CHAIN_ID=1 make unpack`.
-

--- a/custom_overrides.yaml
+++ b/custom_overrides.yaml
@@ -5,3 +5,5 @@ AccountsToFund:
 GovParams:
   votingperiod: 10s
   maxdepositperiod: 10s
+  quorum: 0
+  threshold: 0

--- a/injective-1/cli/apply-upgrade-v1.16.3.sh
+++ b/injective-1/cli/apply-upgrade-v1.16.3.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+ECHO_ONLY=
+TX_OPTS="--keyring-backend=test --from=account0 --chain-id=injective-1 --gas-prices 500000000inj --gas=auto --gas-adjustment=1.5 --broadcast-mode=sync --yes"
+
+# calculate halt height
+CUR_HEIGHT=$(curl -sS http://localhost:26657/block | jq .result.block.header.height | tr -d '"')
+HALT_HEIGHT=$(($CUR_HEIGHT + 60))
+
+fetch_proposal_id() {
+    current_proposal_id=$(curl 'http://localhost:10337/cosmos/gov/v1beta1/proposals?proposal_status=0&pagination.limit=1&pagination.reverse=true' | jq -r '.proposals[].proposal_id')
+    proposal=$((current_proposal_id))
+}
+
+post_proposal() {
+    $ECHO_ONLY $(dirname $0)/injectived-cli-v1.16.2.sh tx upgrade software-upgrade v1.16.3 \
+    --title "UPGRADE_v1.16.3_MAIN" \
+    --upgrade-height $HALT_HEIGHT \
+    --summary "UPGRADE_v1.16.3_MAIN" \
+    --deposit 100000000000000000000inj $TX_OPTS \
+    --node "tcp://host.docker.internal:26657" \
+    --no-validate
+}
+
+vote() {
+    PROPOSAL_ID=$1
+    echo $PROPOSAL_ID
+    $ECHO_ONLY $(dirname $0)/injectived-cli-v1.16.2.sh tx \
+        --node "tcp://host.docker.internal:26657" \
+        gov vote $PROPOSAL_ID yes $TX_OPTS
+}
+
+echo "Posting proposal"
+
+post_proposal
+
+sleep 3
+
+echo "Fetching proposal id"
+
+fetch_proposal_id
+
+echo "Voting for proposal"
+
+vote $proposal
+
+echo "Upgrade will apply at height $HALT_HEIGHT"

--- a/injective-1/cli/devnetify-v1.16.2.sh
+++ b/injective-1/cli/devnetify-v1.16.2.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+INJECTIVED="docker run -it --rm \
+    -v $(pwd)/injective-1:/apps/data/injective-1 \
+    -v $(pwd)/custom_overrides.yaml:/apps/data/custom_overrides.yaml:ro \
+    public.ecr.aws/l9h3g6c6/injective-core:v1.16.2-devnetify.3 injectived"
+
+$INJECTIVED --home "./injective-1" bootstrap-devnet --skip-confirmation --custom-overrides ./custom_overrides.yaml injective-1 inj1wpsrkfdqncagtj726cpwzrz4q2yf6gv4m9ah7l

--- a/injective-1/cli/injectived-cli-v1.16.2.sh
+++ b/injective-1/cli/injectived-cli-v1.16.2.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ulimit -n 120000
+
+docker run -it --rm \
+    -v $(pwd)/injective-1:/apps/data/injective-1 \
+    public.ecr.aws/l9h3g6c6/injective-core:v1.16.2-devnetify.3 injectived \
+    --home "./injective-1" \
+    ${*:-"query"}

--- a/injective-1/cli/injectived-v1.16.2.sh
+++ b/injective-1/cli/injectived-v1.16.2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ulimit -n 120000
+
+docker run -it --rm \
+    -p 26657:26657 \
+    -p 10337:10337 \
+    -v $(pwd)/injective-1:/apps/data/injective-1 \
+    public.ecr.aws/l9h3g6c6/injective-core:v1.16.2-devnetify.3 injectived \
+    --log-level "info" \
+    --home "./injective-1" \
+    start

--- a/injective-1/config/app.toml
+++ b/injective-1/config/app.toml
@@ -182,6 +182,90 @@ max-send-msg-size = "2147483647"
 enable = true
 
 ###############################################################################
+###                             EVM Configuration                           ###
+###############################################################################
+
+[evm]
+
+# Tracer defines the 'vm.Tracer' type that the EVM will use when the node is run in
+# debug mode. To enable tracing use the '--evm.tracer' flag when starting your node.
+# Valid types are: json|struct|access_list|markdown
+tracer = ""
+
+# MaxTxGasWanted defines the gas wanted for each eth tx returned in ante handler in check tx mode.
+max-tx-gas-wanted = 0
+
+###############################################################################
+###                           JSON RPC Configuration                        ###
+###############################################################################
+
+[json-rpc]
+
+# Enable defines if the gRPC server should be enabled.
+enable = true
+
+# Address defines the EVM RPC HTTP server address to bind to.
+address = "127.0.0.1:8545"
+
+# Address defines the EVM WebSocket server address to bind to.
+ws-address = "127.0.0.1:8546"
+
+# API defines a list of JSON-RPC namespaces that should be enabled
+# Example: "eth,txpool,personal,net,debug,web3"
+api = "eth,net,web3"
+
+# GasCap sets a cap on gas that can be used in eth_call/estimateGas (0=infinite).
+gas-cap = 25000000
+
+# EVMTimeout is the global timeout for eth_call. Default: 5s.
+evm-timeout = "5s"
+
+# TxFeeCap is the global tx-fee cap for send transaction. Default: 1eth.
+txfee-cap = 1
+
+# FilterCap sets the global cap for total number of filters that can be created
+filter-cap = 200
+
+# FeeHistoryCap sets the global cap for total number of blocks that can be fetched
+feehistory-cap = 100
+
+# LogsCap defines the max number of results can be returned from single 'eth_getLogs' query.
+logs-cap = 10000
+
+# BlockRangeCap defines the max block range allowed for 'eth_getLogs' query.
+block-range-cap = 10000
+
+# HTTPTimeout is the read/write timeout of http json-rpc server.
+http-timeout = "30s"
+
+# HTTPIdleTimeout is the idle timeout of http json-rpc server.
+http-idle-timeout = "2m0s"
+
+# AllowUnprotectedTxs restricts unprotected (non EIP155 signed) transactions to be submitted via
+# the node's RPC when the global parameter is disabled.
+allow-unprotected-txs = false
+
+# MaxOpenConnections sets the maximum number of simultaneous connections
+# for the server listener.
+max-open-connections = 0
+
+# EnableIndexer enables the custom transaction indexer for the EVM (ethereum transactions).
+enable-indexer = true
+
+# AllowIndexerGap allow block gap for the custom transaction indexer for the EVM (ethereum transactions).
+allow-indexer-gap = true
+
+# Define if JSON-RPC metrics server should be enabled.
+metrics = false
+
+# MetricsAddress defines the EVM Metrics server address to bind to.
+# Prometheus metrics path: /debug/metrics/prometheus
+metrics-address = "127.0.0.1:6065"
+
+# Maximum number of bytes returned from eth_call or similar invocations.
+return-data-limit = 512000
+
+###############################################################################
 ###                        State Sync Configuration                         ###
 ###############################################################################
 

--- a/injective-1/config/config.toml
+++ b/injective-1/config/config.toml
@@ -8,7 +8,7 @@
 
 # The version of the CometBFT binary that created or
 # last modified the config file. Do not modify this.
-version = "0.38.17"
+version = "1.0.1"
 
 #######################################################################
 ###                   Main Base Config Options                      ###
@@ -91,7 +91,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:26657"
+laddr = "tcp://127.0.0.1:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support


### PR DESCRIPTION
- Fixes README lint errors
- Adds quorum and threshold in custom overrides to allow proposals to pass from `--from=account0`
- Add all necessary scripts to devnetify mainnet state from v1.16.2 and upgrade it to v1.16.3
- Update README instruction in mainnet section
- Updated app and config toml files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Dockerized node and CLI wrappers and a devnet bootstrap for v1.16.2.
  * Automated upgrade helper to post and vote for v1.16.3.
  * Added EVM and JSON-RPC configuration and updated local node defaults (including RPC binding and config version).
  * Default governance params added (quorum=0, threshold=0) for local testing.

* Documentation
  * README hierarchy and upgrade workflows updated to 1.16.x; testnet/mainnet steps refreshed.
  * Endpoint examples switched to HTTP-highlighted blocks; minor formatting cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->